### PR TITLE
Replace Python for loop with jax.lax.scan in step_n

### DIFF
--- a/src/scoremd/simulation.py
+++ b/src/scoremd/simulation.py
@@ -42,9 +42,13 @@ def create_langevin_step_function(
         return step_single
 
     def step_n(x: jnp.ndarray, v: jnp.ndarray, key: jax.random.PRNGKey, **kwargs) -> Tuple[jnp.ndarray, jnp.ndarray]:
-        for _ in range(num_steps):
+        def scan_step(carry, _):
+            x, v, key = carry
             key, step_key = jax.random.split(key)
             x, v = step_single(x, v, step_key, **kwargs)
+            return (x, v, key), None
+
+        (x, v, _), _ = jax.lax.scan(scan_step, (x, v, key), None, length=num_steps)
         return x, v
 
     return step_n


### PR DESCRIPTION
Currently, step_n uses a Python for loop to iterate over Langevin steps. While correct, this causes JAX to unroll the full loop at trace/compile time, which leads to longer compilation times and higher memory usage as num_steps grows.

This PR replaces the loop with jax.lax.scan, which compiles the loop body once regardless of num_steps, making compilation time constant and reduces memory.

The behavior is identical — same random key splitting logic, same step_single calls, same outputs. The **kwargs are captured via closure inside scan_step, which works correctly as long as kwargs don't vary per step (consistent with the existing usage).